### PR TITLE
card-panel-names-are-fixed

### DIFF
--- a/src/app/devicemanagement/layout/devicemanagement.component.scss
+++ b/src/app/devicemanagement/layout/devicemanagement.component.scss
@@ -948,8 +948,12 @@ section {
           filter: invert(1);
        }
     }
-    .mat-tab-label-content{
-        color: white;
+     ::ng-deep #selectedTabs .mat-tab-label {
+      color: white !important;
+    }
+
+    :host ::ng-deep #selectedTabs .mat-tab-label-content {
+      color:white !important;
     }
  }
  


### PR DESCRIPTION
Card/Panel names are not displayed in the Modbus Configuration UI